### PR TITLE
Fix searching

### DIFF
--- a/components/Act/ActListSection.js
+++ b/components/Act/ActListSection.js
@@ -62,7 +62,8 @@ export const ActListSection = () => {
     setSearch(e)
     if (e) {
       const value = escapeRegex(e)
-      router.replace(router.pathname, { query: { search: value } }, { shallow: true })
+      history.replaceState({ search: value }, `Search results for ${value}`, `?search=${value}`)
+      // router.replace(router.pathname, { query: { search: value } }, { shallow: true })
     }
   }
 


### PR DESCRIPTION
The issue with searching was the router.replace would lose the type (ask/offer) of the page and the FormattedMessage in actlistpage breaks.

Using history.replaceState fixes this and doesn't cause the frontend to refresh or re-render.
(It also doesn't update the components at all, but that is what the setSearch fn does).